### PR TITLE
카운팅 로직 개선

### DIFF
--- a/backend/newsseug/docker-compose.local.yml
+++ b/backend/newsseug/docker-compose.local.yml
@@ -53,26 +53,6 @@ services:
     networks:
       - local-bridge
 
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: prometheus
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-    ports:
-      - 8887:9090
-    extra_hosts:
-      host.docker.internal: host-gateway
-    networks:
-      - local-bridge
-
-  grafana:
-    image: grafana/grafana:latest
-    container_name: grafana
-    ports:
-      - 3030:3000
-    networks:
-      - local-bridge
-
 networks:
   local-bridge:
     driver: bridge

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/service/ArticleServiceImpl.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/service/ArticleServiceImpl.java
@@ -36,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ArticleServiceImpl implements ArticleService {
 
     private final RedisCounterService redisCounterService;
@@ -49,11 +50,10 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     public GetArticleDetailsResponse getArticleDetail(CustomUserDetails userDetails,
-            Long articleId) {
+                                                      Long articleId) {
 
         Article article = articleRepository.getOrThrow(articleId);
-        Long incrementedViewCount = redisCounterService.increment("article:viewCount:", articleId,
-                1L);
+        Long incrementedViewCount = redisCounterService.increment("article:viewCount:", articleId, 1L);
         Long likeCount = redisCounterService.findByKey("article:likeCount:", articleId).orElse(0L);
         Long hateCount = redisCounterService.findByKey("article:hateCount:", articleId).orElse(0L);
 
@@ -124,7 +124,7 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     public SlicedResponse<List<GetArticleResponse>> getTodayArticlesByCategory(String category,
-            int pageNumber) {
+                                                                               int pageNumber) {
 
         Pageable pageable = PageRequest.of(pageNumber, 10);
         LocalDateTime startOfDay = ClockUtil.getLocalDateTime().toLocalDate().atStartOfDay();
@@ -141,7 +141,7 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     public SlicedResponse<List<GetArticleResponse>> getArticlesByCategory(String category,
-            int pageNumber) {
+                                                                          int pageNumber) {
 
         Pageable pageable = PageRequest.of(pageNumber, 10);
         Slice<Article> sliced = articleRepository.findAllByCategory(category, pageable);
@@ -154,7 +154,6 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public SlicedResponse<List<GetArticleResponse>> getArticlesByPress(
             CustomUserDetails userDetails, Long pressId, int pageNumber, String category
     ) {

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/model/dto/event/HateCountingEvent.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/model/dto/event/HateCountingEvent.java
@@ -1,0 +1,16 @@
+package com.a301.newsseug.domain.interaction.model.dto.event;
+
+import lombok.Builder;
+
+@Builder
+public record HateCountingEvent(String hash, Long id, Long delta) {
+
+    public static HateCountingEvent of(String hash, Long id, Long delta) {
+        return HateCountingEvent.builder()
+                .hash(hash)
+                .id(id)
+                .delta(delta)
+                .build();
+    }
+
+}

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/model/dto/event/LikeCountingEvent.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/model/dto/event/LikeCountingEvent.java
@@ -1,0 +1,16 @@
+package com.a301.newsseug.domain.interaction.model.dto.event;
+
+import lombok.Builder;
+
+@Builder
+public record LikeCountingEvent(String hash, Long id, Long delta) {
+
+    public static LikeCountingEvent of(String hash, Long id, Long delta) {
+        return LikeCountingEvent.builder()
+                .hash(hash)
+                .id(id)
+                .delta(delta)
+                .build();
+    }
+
+}

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/model/entity/Hate.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/model/entity/Hate.java
@@ -14,7 +14,15 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "hates")
+@Table(
+        name = "hates",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uniqueLike",
+                        columnNames = {"member_id", "article_id"}
+                )
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Hate {
 

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/model/entity/Like.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/model/entity/Like.java
@@ -14,7 +14,15 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "likes")
+@Table(
+        name = "likes",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uniqueLike",
+                        columnNames = {"member_id", "article_id"}
+                )
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Like {
 

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/repository/HistoryRepository.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/repository/HistoryRepository.java
@@ -5,7 +5,6 @@ import com.a301.newsseug.domain.interaction.model.entity.History;
 import com.a301.newsseug.domain.member.model.entity.Member;
 
 import com.a301.newsseug.global.model.entity.ActivationStatus;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/service/LikeServiceImpl.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/service/LikeServiceImpl.java
@@ -4,6 +4,8 @@ import com.a301.newsseug.domain.article.model.entity.Article;
 import com.a301.newsseug.domain.article.repository.ArticleRepository;
 import com.a301.newsseug.domain.article.service.RedisCounterService;
 import com.a301.newsseug.domain.auth.model.entity.CustomUserDetails;
+import com.a301.newsseug.domain.interaction.model.dto.event.HateCountingEvent;
+import com.a301.newsseug.domain.interaction.model.dto.event.LikeCountingEvent;
 import com.a301.newsseug.domain.interaction.model.entity.Hate;
 import com.a301.newsseug.domain.interaction.model.entity.Like;
 import com.a301.newsseug.domain.interaction.repository.HateRepository;
@@ -11,6 +13,7 @@ import com.a301.newsseug.domain.interaction.repository.LikeRepository;
 import com.a301.newsseug.domain.member.model.entity.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
@@ -20,6 +23,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class LikeServiceImpl implements LikeService {
 
+    private final ApplicationEventPublisher eventPublisher;
     private final ArticleRepository articleRepository;
     private final LikeRepository likeRepository;
     private final HateRepository hateRepository;
@@ -32,10 +36,16 @@ public class LikeServiceImpl implements LikeService {
         Member loginMember = userDetails.getMember();
         Article article = articleRepository.getOrThrow(articleId);
         Optional<Hate> hate = hateRepository.findByMemberAndArticle(loginMember, article);
-
         if(hate.isPresent()) {
             hateRepository.delete(hate.get());
             redisCounterService.incrementAsync("article:hateCount:", articleId, -1L);
+            eventPublisher.publishEvent(
+                    HateCountingEvent.builder()
+                            .hash("article:hateCount:")
+                            .id(articleId)
+                            .delta(-1L)
+                            .build()
+            );
         }
 
         likeRepository.save(Like.builder()
@@ -43,7 +53,14 @@ public class LikeServiceImpl implements LikeService {
                 .article(article)
                 .build()
         );
-        redisCounterService.incrementAsync("article:likeCount:", articleId, 1L);
+
+        eventPublisher.publishEvent(
+                LikeCountingEvent.builder()
+                        .hash("article:likeCount:")
+                        .id(articleId)
+                        .delta(1L)
+                        .build()
+        );
 
     }
 

--- a/backend/newsseug/src/main/java/com/a301/newsseug/external/redis/config/RedisEventListener.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/external/redis/config/RedisEventListener.java
@@ -1,0 +1,27 @@
+package com.a301.newsseug.external.redis.config;
+
+import com.a301.newsseug.domain.article.service.RedisCounterService;
+import com.a301.newsseug.domain.interaction.model.dto.event.HateCountingEvent;
+import com.a301.newsseug.domain.interaction.model.dto.event.LikeCountingEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class RedisEventListener {
+
+    private final RedisCounterService redisCounterService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLikeCountingEvent(LikeCountingEvent event) {
+        redisCounterService.incrementAsync(event.hash(), event.id(), event.delta());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleHateCountingEvent(HateCountingEvent event) {
+        redisCounterService.incrementAsync(event.hash(), event.id(), event.delta());
+    }
+
+}

--- a/backend/newsseug/src/main/resources/schema.sql
+++ b/backend/newsseug/src/main/resources/schema.sql
@@ -16,137 +16,139 @@ CREATE SEQUENCE IF NOT EXISTS birth_year_view_counts_seq START WITH 1 INCREMENT 
 
 -- Create tables
 CREATE TABLE IF NOT EXISTS members (
-    member_id         BIGINT PRIMARY KEY DEFAULT nextval(members_seq),
-    birth             DATE NULL,
-    nickname          VARCHAR(255) NULL,
-    profile_image_url VARCHAR(255) NULL,
-    is_first          BIT(1) NOT NULL DEFAULT TRUE,
-    provider_id       VARCHAR(255) NOT NULL,
-    gender            ENUM ('FEMALE', 'MALE') NULL,
-    provider          ENUM ('GOOGLE', 'KAKAO') NOT NULL,
-    role              ENUM ('ROLE_ADMIN', 'ROLE_MEMBER') NULL,
-    activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
-    created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT UKilvrhdmws4av314ebhvn26im5 UNIQUE (provider_id)
+                                       member_id         BIGINT PRIMARY KEY DEFAULT nextval(members_seq),
+                                       birth             DATE NULL,
+                                       nickname          VARCHAR(255) NULL,
+                                       profile_image_url VARCHAR(255) NULL,
+                                       is_first          BIT(1) NOT NULL DEFAULT TRUE,
+                                       provider_id       VARCHAR(255) NOT NULL,
+                                       gender            ENUM ('FEMALE', 'MALE') NULL,
+                                       provider          ENUM ('GOOGLE', 'KAKAO') NOT NULL,
+                                       role              ENUM ('ROLE_ADMIN', 'ROLE_MEMBER') NULL,
+                                       activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
+                                       created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                       updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                       CONSTRAINT UKilvrhdmws4av314ebhvn26im5 UNIQUE (provider_id)
 );
 
 CREATE TABLE IF NOT EXISTS folders (
-    folder_id         BIGINT PRIMARY KEY DEFAULT nextval(folders_seq),
-    member_id         BIGINT  NOT NULL,
-    article_count     BIGINT NULL,
-    thumbnail_url     VARCHAR(255) NULL,
-    title             VARCHAR(10)  NOT NULL,
-    activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
-    created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT FKco4xraxvdqyci1h0bfgnvq1yf FOREIGN KEY (member_id) REFERENCES members (member_id) ON DELETE CASCADE
+                                       folder_id         BIGINT PRIMARY KEY DEFAULT nextval(folders_seq),
+                                       member_id         BIGINT  NOT NULL,
+                                       article_count     BIGINT NULL,
+                                       thumbnail_url     VARCHAR(255) NULL,
+                                       title             VARCHAR(10)  NOT NULL,
+                                       activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
+                                       created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                       updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                       CONSTRAINT FKco4xraxvdqyci1h0bfgnvq1yf FOREIGN KEY (member_id) REFERENCES members (member_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS press (
-    press_id          BIGINT PRIMARY KEY DEFAULT nextval(press_seq),
-    subscribe_count   BIGINT NULL DEFAULT 0,
-    description       VARCHAR(255) NULL,
-    image_url         VARCHAR(255) NULL,
-    name              VARCHAR(255) NULL,
-    activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
-    created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                     press_id          BIGINT PRIMARY KEY DEFAULT nextval(press_seq),
+                                     subscribe_count   BIGINT NULL DEFAULT 0,
+                                     description       VARCHAR(255) NULL,
+                                     image_url         VARCHAR(255) NULL,
+                                     name              VARCHAR(255) NULL,
+                                     activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
+                                     created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                     updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS articles (
-    article_id        BIGINT PRIMARY KEY DEFAULT nextval(articles_seq),
-    press_id          BIGINT  NOT NULL,
-    hate_count        BIGINT  NOT NULL DEFAULT 0,
-    like_count        BIGINT  NOT NULL DEFAULT 0,
-    source_created_at TIMESTAMP NULL,
-    view_count        BIGINT  NOT NULL DEFAULT 0,
-    content_url       VARCHAR(255) NULL,
-    source_url        VARCHAR(255)  NOT NULL,
-    thumbnail_url     VARCHAR(255) NULL,
-    title             VARCHAR(255)  NOT NULL,
-    video_url         VARCHAR(255) NULL,
-    category          ENUM ('ACCIDENT', 'ECONOMY', 'POLITICS', 'SCIENCE', 'SOCIETY', 'SPORTS', 'WORLD')  NOT NULL,
-    conversion_status ENUM ('EXCEED_TOKEN', 'FILTERED', 'RUNNING', 'SUCCESS', 'UNKNOWN_FAIL')  NOT NULL,
-    activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
-    created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT FKd04v02rcdg3lmlu45mw9vfomc FOREIGN KEY (press_id) REFERENCES press (press_id) ON DELETE CASCADE
+                                        article_id        BIGINT PRIMARY KEY DEFAULT nextval(articles_seq),
+                                        press_id          BIGINT  NOT NULL,
+                                        hate_count        BIGINT  NOT NULL DEFAULT 0,
+                                        like_count        BIGINT  NOT NULL DEFAULT 0,
+                                        source_created_at TIMESTAMP NULL,
+                                        view_count        BIGINT  NOT NULL DEFAULT 0,
+                                        content_url       VARCHAR(255) NULL,
+                                        source_url        VARCHAR(255)  NOT NULL,
+                                        thumbnail_url     VARCHAR(255) NULL,
+                                        title             VARCHAR(255)  NOT NULL,
+                                        video_url         VARCHAR(255) NULL,
+                                        category          ENUM ('ACCIDENT', 'ECONOMY', 'POLITICS', 'SCIENCE', 'SOCIETY', 'SPORTS', 'WORLD')  NOT NULL,
+                                        conversion_status ENUM ('EXCEED_TOKEN', 'FILTERED', 'RUNNING', 'SUCCESS', 'UNKNOWN_FAIL')  NOT NULL,
+                                        activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
+                                        created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                        updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                        CONSTRAINT FKd04v02rcdg3lmlu45mw9vfomc FOREIGN KEY (press_id) REFERENCES press (press_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS bookmarks (
-    bookmark_id       BIGINT PRIMARY KEY DEFAULT nextval(bookmarks_seq),
-    folder_id         BIGINT  NOT NULL,
-    article_id        BIGINT  NOT NULL,
-    activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
-    created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT uniqueBookmark UNIQUE (article_id, folder_id),
-    CONSTRAINT FKgw1od0yvy1n3r2p0r4cb7x57a FOREIGN KEY (folder_id) REFERENCES folders (folder_id) ON DELETE CASCADE,
-    CONSTRAINT FKrgc71ng0qy59rn9y741gi2mjr FOREIGN KEY (article_id) REFERENCES articles (article_id) ON DELETE CASCADE
+                                         bookmark_id       BIGINT PRIMARY KEY DEFAULT nextval(bookmarks_seq),
+                                         folder_id         BIGINT  NOT NULL,
+                                         article_id        BIGINT  NOT NULL,
+                                         activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
+                                         created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                         updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                         CONSTRAINT uniqueBookmark UNIQUE (article_id, folder_id),
+                                         CONSTRAINT FKgw1od0yvy1n3r2p0r4cb7x57a FOREIGN KEY (folder_id) REFERENCES folders (folder_id) ON DELETE CASCADE,
+                                         CONSTRAINT FKrgc71ng0qy59rn9y741gi2mjr FOREIGN KEY (article_id) REFERENCES articles (article_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS histories (
-    history_id        BIGINT PRIMARY KEY DEFAULT nextval(histories_seq),
-    member_id         BIGINT  NOT NULL,
-    article_id        BIGINT  NOT NULL,
-    play_time         INT  NOT NULL,
-    activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
-    created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT uniqueBookmark UNIQUE (member_id, article_id),
-    CONSTRAINT FKr5eq32k17h6xd5u1ridpahnlg FOREIGN KEY (member_id) REFERENCES members (member_id) ON DELETE CASCADE,
-    CONSTRAINT FK6dwu9pkt9gecpbk3r8u4oqk7n FOREIGN KEY (article_id) REFERENCES articles (article_id) ON DELETE CASCADE
+                                         history_id        BIGINT PRIMARY KEY DEFAULT nextval(histories_seq),
+                                         member_id         BIGINT  NOT NULL,
+                                         article_id        BIGINT  NOT NULL,
+                                         play_time         INT  NOT NULL,
+                                         activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
+                                         created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                         updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                         CONSTRAINT uniqueBookmark UNIQUE (member_id, article_id),
+                                         CONSTRAINT FKr5eq32k17h6xd5u1ridpahnlg FOREIGN KEY (member_id) REFERENCES members (member_id) ON DELETE CASCADE,
+                                         CONSTRAINT FK6dwu9pkt9gecpbk3r8u4oqk7n FOREIGN KEY (article_id) REFERENCES articles (article_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS likes (
-    like_id           BIGINT PRIMARY KEY DEFAULT nextval(likes_seq),
-    member_id         BIGINT  NOT NULL,
-    article_id        BIGINT  NOT NULL,
-    activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
-    created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT FK166rh7nhmtcajf0xo1f1i3s8p FOREIGN KEY (member_id) REFERENCES members (member_id) ON DELETE CASCADE,
-    CONSTRAINT FKic6sfk54mitq78b48367cfiet FOREIGN KEY (article_id) REFERENCES articles (article_id) ON DELETE CASCADE
+                                     like_id           BIGINT PRIMARY KEY DEFAULT nextval(likes_seq),
+                                     member_id         BIGINT  NOT NULL,
+                                     article_id        BIGINT  NOT NULL,
+                                     activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
+                                     created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                     updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                     CONSTRAINT uniqueLike UNIQUE (member_id, article_id),
+                                     CONSTRAINT FK166rh7nhmtcajf0xo1f1i3s8p FOREIGN KEY (member_id) REFERENCES members (member_id) ON DELETE CASCADE,
+                                     CONSTRAINT FKic6sfk54mitq78b48367cfiet FOREIGN KEY (article_id) REFERENCES articles (article_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS hates (
-    hate_id           BIGINT PRIMARY KEY DEFAULT nextval(hates_seq),
-    member_id         BIGINT  NOT NULL,
-    article_id        BIGINT  NOT NULL,
-    activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
-    created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT FKeu114uu249552fnxpjoesei59 FOREIGN KEY (member_id) REFERENCES members (member_id) ON DELETE CASCADE,
-    CONSTRAINT FKp1hq7yrqfyhean2q5gj53i4em FOREIGN KEY (article_id) REFERENCES articles (article_id) ON DELETE CASCADE
+                                     hate_id           BIGINT PRIMARY KEY DEFAULT nextval(hates_seq),
+                                     member_id         BIGINT  NOT NULL,
+                                     article_id        BIGINT  NOT NULL,
+                                     activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
+                                     created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                     updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                     CONSTRAINT uniqueHate UNIQUE (member_id, article_id),
+                                     CONSTRAINT FKeu114uu249552fnxpjoesei59 FOREIGN KEY (member_id) REFERENCES members (member_id) ON DELETE CASCADE,
+                                     CONSTRAINT FKp1hq7yrqfyhean2q5gj53i4em FOREIGN KEY (article_id) REFERENCES articles (article_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS reports (
-    report_id         BIGINT PRIMARY KEY DEFAULT nextval(reports_seq),
-    article_id        BIGINT  NOT NULL,
-    type              ENUM ('DISLIKE', 'EXPLICIT_CONTENT', 'HATE_SPEECH_OR_SYMBOLS', 'MISINFORMATION', 'SPAM')  NOT NULL,
-    activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
-    created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT FKvd08qavn9nwy8fa6n5349tb7 FOREIGN KEY (article_id) REFERENCES articles (article_id) ON DELETE CASCADE
+                                       report_id         BIGINT PRIMARY KEY DEFAULT nextval(reports_seq),
+                                       article_id        BIGINT  NOT NULL,
+                                       type              ENUM ('DISLIKE', 'EXPLICIT_CONTENT', 'HATE_SPEECH_OR_SYMBOLS', 'MISINFORMATION', 'SPAM')  NOT NULL,
+                                       activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
+                                       created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                       updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                       CONSTRAINT FKvd08qavn9nwy8fa6n5349tb7 FOREIGN KEY (article_id) REFERENCES articles (article_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS subscribes (
-    subscribe_id      BIGINT PRIMARY KEY DEFAULT nextval(subscribes_seq),
-    member_id         BIGINT NULL,
-    press_id          BIGINT NULL,
-    activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
-    created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT uniqueSubscribe UNIQUE (member_id, press_id),
-    CONSTRAINT FK1ll7f1tjs7lt3xiqfcbrfmdum FOREIGN KEY (member_id) REFERENCES members (member_id) ON DELETE CASCADE,
-    CONSTRAINT FKj3n9k136ixactnmfdhflm2i4n FOREIGN KEY (press_id) REFERENCES press (press_id) ON DELETE CASCADE
+                                          subscribe_id      BIGINT PRIMARY KEY DEFAULT nextval(subscribes_seq),
+                                          member_id         BIGINT NULL,
+                                          press_id          BIGINT NULL,
+                                          activation_status ENUM ('ACTIVE', 'INACTIVE')  NOT NULL DEFAULT 'ACTIVE',
+                                          created_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                          updated_at        TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                          CONSTRAINT uniqueSubscribe UNIQUE (member_id, press_id),
+                                          CONSTRAINT FK1ll7f1tjs7lt3xiqfcbrfmdum FOREIGN KEY (member_id) REFERENCES members (member_id) ON DELETE CASCADE,
+                                          CONSTRAINT FKj3n9k136ixactnmfdhflm2i4n FOREIGN KEY (press_id) REFERENCES press (press_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS birth_year_view_counts (
-    birth_view_count_id BIGINT PRIMARY KEY DEFAULT nextval(birth_year_view_counts_seq),
-    article_id          BIGINT NOT NULL,
-    birth_year          INT    NULL,
-    view_count          BIGINT NOT NULL DEFAULT 0,
-    CONSTRAINT FK4hy7ruduqtt8ugpj8hx5ajrpc FOREIGN KEY (article_id) REFERENCES articles (article_id)
+                                                      birth_view_count_id BIGINT PRIMARY KEY DEFAULT nextval(birth_year_view_counts_seq),
+                                                      article_id          BIGINT NOT NULL,
+                                                      birth_year          INT    NULL,
+                                                      view_count          BIGINT NOT NULL DEFAULT 0,
+                                                      CONSTRAINT FK4hy7ruduqtt8ugpj8hx5ajrpc FOREIGN KEY (article_id) REFERENCES articles (article_id)
 );


### PR DESCRIPTION
## 기존 방식
단순히 비동기로 실행
```
@Override
@Transactional
public void createLike(CustomUserDetails userDetails, Long articleId) {

    Member loginMember = userDetails.getMember();
    Article article = articleRepository.getOrThrow(articleId);
    Optional<Hate> hate = hateRepository.findByMemberAndArticle(loginMember, article);
		
    // 좋아요를 눌렀을 때 싫어요가 존재하면 이를 삭제 후 카운트 감소
    if(hate.isPresent()) {
        hateRepository.delete(hate.get());
        redisCounterService.incrementAsync("article:hateCount:", articleId, -1L);
    }
		
    // 그렇지 않다면 좋아요를 생성
    likeRepository.save(Like.builder()
            .member(loginMember)
            .article(article)
            .build()
    );
    
    // 좋아요 카운팅
    redisCounterService.increment("article:likeCount:", articleId, 1L);

}
```

## 수정 후
이벤트 발생을 통해 트랜잭션 종료를 감지하여 증가 로직 수행
```
 @Override
    @Transactional
    public void createLike(CustomUserDetails userDetails, Long articleId) {

        Member loginMember = userDetails.getMember();
        Article article = articleRepository.getOrThrow(articleId);
        Optional<Hate> hate = hateRepository.findByMemberAndArticle(loginMember, article);
        if(hate.isPresent()) {
            hateRepository.delete(hate.get());
            redisCounterService.incrementAsync("article:hateCount:", articleId, -1L);
            eventPublisher.publishEvent(
                    HateCountingEvent.builder()
                            .hash("article:hateCount:")
                            .id(articleId)
                            .delta(-1L)
                            .build()
            );
        }

        likeRepository.save(Like.builder()
                .member(loginMember)
                .article(article)
                .build()
        );

        eventPublisher.publishEvent(
                LikeCountingEvent.builder()
                        .hash("article:likeCount:")
                        .id(articleId)
                        .delta(1L)
                        .build()
        );

    }
```

## 수정한 이유
단순히 비동기로 수행할 경우 좋아요, 싫어요 등 트랜잭션 롤백이 수행되었을 때 이를 감지하고 못하고 카운팅이 실행된다. 이를 보완하기 위해 이벤트 핸들링을 통해 트랜잭션이 종료된 후 수행하도록 했음.
