### PR TITLE
[Refactor] 언론사 조회에 대한 로컬 캐시 적용

### DIFF
--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/model/dto/ArticleSummaryDto.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/model/dto/ArticleSummaryDto.java
@@ -1,0 +1,30 @@
+package com.a301.newsseug.domain.article.model.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArticleSummaryDto {
+
+    private Long id;
+    private String thumbnailUrl;
+    private String title;
+    private Long viewCount;
+    private LocalDateTime createdAt;
+    private Long pressId;
+
+    @QueryProjection
+    public ArticleSummaryDto(Long id, String thumbnailUrl, String title, Long viewCount, LocalDateTime createdAt, Long pressId) {
+        this.id = id;
+        this.thumbnailUrl = thumbnailUrl;
+        this.title = title;
+        this.viewCount = viewCount;
+        this.createdAt = createdAt;
+        this.pressId = pressId;
+    }
+
+}

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/model/dto/response/GetArticleSummaryResponseDto.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/model/dto/response/GetArticleSummaryResponseDto.java
@@ -1,8 +1,9 @@
 package com.a301.newsseug.domain.article.model.dto.response;
 
+import com.a301.newsseug.domain.article.model.dto.ArticleSummaryDto;
 import com.a301.newsseug.domain.article.model.entity.Article;
 import com.a301.newsseug.domain.bookmark.model.entity.Bookmark;
-import com.querydsl.core.annotations.QueryProjection;
+import com.a301.newsseug.domain.press.model.entity.Press;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,9 +21,6 @@ public class GetArticleSummaryResponseDto {
     @Schema(description = "식별자", examples = {"99"})
     private Long id;
 
-    @Schema(description = "언론사 이름", examples = {"조선일보"})
-    private String pressName;
-
     @Schema(description = "썸네일", examples = {"https://{bucket-name}~amazonaws.com/{directory-name}/{thumbnail-url}"})
     private String thumbnailUrl;
 
@@ -35,32 +33,38 @@ public class GetArticleSummaryResponseDto {
     @Schema(description = "생성일", examples = {"20240423"})
     private LocalDateTime createdAt;
 
+    private String pressName;
+
     @Builder
-    @QueryProjection
-    public GetArticleSummaryResponseDto(Long id, String pressName, String thumbnailUrl, String title, Long viewCount, LocalDateTime createdAt) {
+    public GetArticleSummaryResponseDto(Long id, String thumbnailUrl, String title, Long viewCount, LocalDateTime createdAt, String pressName) {
         this.id = id;
-        this.pressName = pressName;
         this.thumbnailUrl = thumbnailUrl;
         this.title = title;
         this.viewCount = viewCount;
         this.createdAt = createdAt;
+        this.pressName = pressName;
     }
 
     public static GetArticleSummaryResponseDto of(Article article) {
         return GetArticleSummaryResponseDto.builder()
                 .id(article.getId())
-                .pressName(article.getPress().getName())
                 .thumbnailUrl(article.getThumbnailUrl())
                 .title(article.getTitle())
                 .viewCount(article.getViewCount())
-                .createdAt(article.getSourceCreatedAt())
+                .createdAt(article.getCreatedAt())
+                .pressName(article.getPress().getName())
                 .build();
     }
 
-    public static List<GetArticleSummaryResponseDto> of(List<Article> article) {
-        return article.stream()
-                .map(GetArticleSummaryResponseDto::of)
-                .toList();
+    public static GetArticleSummaryResponseDto of(ArticleSummaryDto article, Press press) {
+        return GetArticleSummaryResponseDto.builder()
+                .id(article.getId())
+                .thumbnailUrl(article.getThumbnailUrl())
+                .title(article.getTitle())
+                .viewCount(article.getViewCount())
+                .createdAt(article.getCreatedAt())
+                .pressName(press.getName())
+                .build();
     }
 
     public static List<GetArticleSummaryResponseDto> fromBookmark(List<Bookmark> bookmarks) {

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/model/entity/Article.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/model/entity/Article.java
@@ -30,9 +30,6 @@ public class Article extends BaseEntity {
     private Press press;
 
     @Column(nullable = false)
-    private String pressName;
-
-    @Column(nullable = false)
     private String title;
 
     @Column(nullable = false)
@@ -69,7 +66,6 @@ public class Article extends BaseEntity {
             Press press, String title, String sourceUrl, String contentUrl, String videoUrl, String thumbnailUrl, CategoryType category
     ) {
         this.press = press;
-        this.pressName = press.getName();
         this.title = title;
         this.sourceUrl = sourceUrl;
         this.contentUrl = contentUrl;

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/repository/ArticleCustomRepository.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/repository/ArticleCustomRepository.java
@@ -1,6 +1,7 @@
 package com.a301.newsseug.domain.article.repository;
 
 import com.a301.newsseug.domain.article.model.dto.ArticleRetrieveCondition;
+import com.a301.newsseug.domain.article.model.dto.ArticleSummaryDto;
 import com.a301.newsseug.domain.article.model.dto.response.GetArticleSummaryResponseDto;
 import com.a301.newsseug.domain.article.model.entity.Article;
 import com.a301.newsseug.domain.press.model.entity.Press;
@@ -12,13 +13,13 @@ import java.util.List;
 
 public interface ArticleCustomRepository {
 
-    Slice<GetArticleSummaryResponseDto> findAllArticlesByCondition(ArticleRetrieveCondition conditions, Pageable pageable);
+    Slice<ArticleSummaryDto> findAllArticlesByCondition(ArticleRetrieveCondition conditions, Pageable pageable);
 
-    Slice<GetArticleSummaryResponseDto> findAllArticlesByPressAndCondition(ArticleRetrieveCondition conditions, Pageable pageable);
+    Slice<ArticleSummaryDto> findAllArticlesByPressAndCondition(ArticleRetrieveCondition conditions, Pageable pageable);
 
-    Slice<GetArticleSummaryResponseDto> findAllArticlesBySubscribedPress(List<Press> pressList, ArticleRetrieveCondition conditions, Pageable pageable);
+    Slice<ArticleSummaryDto> findAllArticlesBySubscribedPress(List<Press> pressList, ArticleRetrieveCondition conditions, Pageable pageable);
 
-    Slice<GetArticleSummaryResponseDto> findAllArticlesByTitle(String keyword, Pageable pageable);
+    Slice<ArticleSummaryDto> findAllArticlesByTitle(String keyword, Pageable pageable);
 
     void batchUpdateCount(String field, Map<String, Long> countingLog);
 

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/repository/ArticleCustomRepositoryImpl.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/repository/ArticleCustomRepositoryImpl.java
@@ -3,17 +3,9 @@ package com.a301.newsseug.domain.article.repository;
 import static com.a301.newsseug.domain.article.model.entity.QArticle.article;
 
 import com.a301.newsseug.domain.article.model.dto.ArticleRetrieveCondition;
-import com.a301.newsseug.domain.article.model.dto.response.GetArticleSummaryResponseDto;
-import com.a301.newsseug.domain.article.model.dto.response.QGetArticleSummaryResponseDto;
-import com.a301.newsseug.domain.article.model.entity.Article;
-import com.a301.newsseug.domain.article.model.entity.type.CategoryType;
-import com.a301.newsseug.domain.article.model.entity.type.ConversionStatus;
+import com.a301.newsseug.domain.article.model.dto.ArticleSummaryDto;
+import com.a301.newsseug.domain.article.model.dto.QArticleSummaryDto;
 import com.a301.newsseug.domain.press.model.entity.Press;
-import com.a301.newsseug.global.model.entity.ActivationStatus;
-import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
@@ -23,8 +15,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -40,24 +30,24 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Slice<GetArticleSummaryResponseDto> findAllArticlesByCondition(
+    public Slice<ArticleSummaryDto> findAllArticlesByCondition(
             ArticleRetrieveCondition conditions, Pageable pageable
     ) {
-        List<GetArticleSummaryResponseDto> articles =
+        List<ArticleSummaryDto> articles =
                 createPagingQuery(pageable).where(conditions.toPredicate()).fetch();
         return toSlice(articles, pageable);
     }
 
     @Override
-    public Slice<GetArticleSummaryResponseDto> findAllArticlesByPressAndCondition(ArticleRetrieveCondition conditions, Pageable pageable) {
-        List<GetArticleSummaryResponseDto> articles =
+    public Slice<ArticleSummaryDto> findAllArticlesByPressAndCondition(ArticleRetrieveCondition conditions, Pageable pageable) {
+        List<ArticleSummaryDto> articles =
                 createPagingQuery(pageable).where(conditions.toPredicate()).fetch();
         return toSlice(articles, pageable);
     }
 
     @Override
-    public Slice<GetArticleSummaryResponseDto> findAllArticlesBySubscribedPress(List<Press> presses, ArticleRetrieveCondition conditions, Pageable pageable) {
-        List<GetArticleSummaryResponseDto> articles =
+    public Slice<ArticleSummaryDto> findAllArticlesBySubscribedPress(List<Press> presses, ArticleRetrieveCondition conditions, Pageable pageable) {
+        List<ArticleSummaryDto> articles =
                 createPagingQuery(pageable)
                         .where(conditions.toPredicate().and(article.press.in(presses)))
                         .fetch();
@@ -65,8 +55,8 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
     }
 
     @Override
-    public Slice<GetArticleSummaryResponseDto> findAllArticlesByTitle(String keyword, Pageable pageable) {
-        List<GetArticleSummaryResponseDto> articles =
+    public Slice<ArticleSummaryDto> findAllArticlesByTitle(String keyword, Pageable pageable) {
+        List<ArticleSummaryDto> articles =
                 createPagingQuery(pageable)
                         .where(article.title.containsIgnoreCase(keyword))
                         .fetch();
@@ -98,73 +88,15 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
                 .execute();
     }
 
-    /**
-     * 공통 조건을 처리하는 메서드
-     * @param category 카테고리 조건
-     * @return BooleanBuilder에 상태와 변환 상태 조건을 추가한 빌더
-     */
-    private BooleanBuilder createBaseCondition(String category) {
-
-        BooleanBuilder builder = new BooleanBuilder();
-
-        if (Objects.nonNull(category) && !category.equalsIgnoreCase("ALL")) {
-            addCategoryCondition(builder, category, article.category::eq);
-        }
-
-        builder.and(article.activationStatus.eq(ActivationStatus.ACTIVE));
-        builder.and(article.conversionStatus.eq(ConversionStatus.SUCCESS));
-
-        return builder;
-
-    }
-
-    private BooleanBuilder createBaseCondition() {
-        BooleanBuilder builder = new BooleanBuilder();
-        builder.and(article.activationStatus.eq(ActivationStatus.ACTIVE));
-        builder.and(article.conversionStatus.eq(ConversionStatus.SUCCESS));
-        return builder;
-    }
-
-    private <T> void addCategoryCondition(BooleanBuilder builder, String value, Function<CategoryType , BooleanExpression> condition) {
-        builder.and(condition.apply(CategoryType.from(value)));
-    }
-
-    /**
-     * 쿼리를 실행하고 Slice로 반환하는 메서드
-     * @param conditions BooleanBuilder에 추가된 조건
-     * @param pageable 페이징 정보
-     * @return Slice<Article>
-     */
-    private Slice<Article> createPagingQuery(BooleanBuilder conditions, Pageable pageable) {
-        List<Article> content = jpaQueryFactory
-                .selectFrom(article)
-                .leftJoin(article.press).fetchJoin()
-                .where(createBaseCondition())
-                .where(conditions)
-                .orderBy(new OrderSpecifier<>(Order.DESC, article.sourceCreatedAt))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
-
-        boolean hasNext = content.size() > pageable.getPageSize();
-
-        if (hasNext) {
-            content.remove(content.size() - 1);
-        }
-
-        return new SliceImpl<>(content, pageable, hasNext);
-
-    }
-
-    private JPAQuery<GetArticleSummaryResponseDto> createPagingQuery(Pageable pageable) {
+    private JPAQuery<ArticleSummaryDto> createPagingQuery(Pageable pageable) {
         return jpaQueryFactory
-                .select(new QGetArticleSummaryResponseDto(
+                .select(new QArticleSummaryDto(
                         article.id,
-                        article.pressName,
                         article.thumbnailUrl,
                         article.title,
                         article.viewCount,
-                        article.sourceCreatedAt
+                        article.sourceCreatedAt,
+                        article.press.id
                 ))
                 .from(article)
                 .orderBy(article.sourceCreatedAt.desc())
@@ -172,7 +104,7 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
                 .limit(pageable.getPageSize() + 1);
     }
 
-    private Slice<GetArticleSummaryResponseDto> toSlice(List<GetArticleSummaryResponseDto> content, Pageable pageable) {
+    private Slice<ArticleSummaryDto> toSlice(List<ArticleSummaryDto> content, Pageable pageable) {
         boolean hasNext = content.size() > pageable.getPageSize();
         if (hasNext) {
             content.remove(content.size() - 1);

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/service/ArticleQueryService.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/service/ArticleQueryService.java
@@ -1,6 +1,7 @@
 package com.a301.newsseug.domain.article.service;
 
 import com.a301.newsseug.domain.article.factory.ArticleConditionFactory;
+import com.a301.newsseug.domain.article.model.dto.ArticleSummaryDto;
 import com.a301.newsseug.domain.article.model.dto.response.GetArticleSummaryResponseDto;
 import com.a301.newsseug.domain.article.model.entity.type.CategoryType;
 import com.a301.newsseug.domain.article.repository.ArticleRepository;
@@ -22,14 +23,14 @@ public class ArticleQueryService {
     private final int PAGE_SIZE = 10;
     private final ArticleRepository articleRepository;
 
-    public Slice<GetArticleSummaryResponseDto> getSlicedArticlesByCategory(CategoryType category, int pageNumber) {
+    public Slice<ArticleSummaryDto> getSlicedArticlesByCategory(CategoryType category, int pageNumber) {
         return articleRepository.findAllArticlesByCondition(
                 ArticleConditionFactory.create(category),
                 PageRequest.of(pageNumber, PAGE_SIZE)
         );
     }
 
-    public Slice<GetArticleSummaryResponseDto> getSlicedTodayArticlesByCategory(CategoryType category, int pageNumber) {
+    public Slice<ArticleSummaryDto> getSlicedTodayArticlesByCategory(CategoryType category, int pageNumber) {
         LocalDateTime startOfDay = ClockUtil.getLocalDateTime().toLocalDate().atStartOfDay();
         return articleRepository.findAllArticlesByCondition(
                 ArticleConditionFactory.create(category, startOfDay, startOfDay.plusDays(1)),
@@ -37,14 +38,14 @@ public class ArticleQueryService {
         );
     }
 
-    public Slice<GetArticleSummaryResponseDto> getSlicedArticlesByPressAndCategory(Press press, CategoryType category, int pageNumber) {
+    public Slice<ArticleSummaryDto> getSlicedArticlesByPressAndCategory(Press press, CategoryType category, int pageNumber) {
         return articleRepository.findAllArticlesByPressAndCondition(
                 ArticleConditionFactory.create(press, category),
                 PageRequest.of(pageNumber, PAGE_SIZE)
         );
     }
 
-    public Slice<GetArticleSummaryResponseDto> getSlicedArticlesBySubscribedPress(List<Press> presses, CategoryType category, int pageNumber) {
+    public Slice<ArticleSummaryDto> getSlicedArticlesBySubscribedPress(List<Press> presses, CategoryType category, int pageNumber) {
         return articleRepository.findAllArticlesBySubscribedPress(
                 presses,
                 ArticleConditionFactory.create(category),
@@ -52,11 +53,8 @@ public class ArticleQueryService {
         );
     }
 
-    public Slice<GetArticleSummaryResponseDto> getSlicedArticlesByTitle(String title, int pageNumber) {
+    public Slice<ArticleSummaryDto> getSlicedArticlesByTitle(String title, int pageNumber) {
         return articleRepository.findAllArticlesByTitle(title, PageRequest.of(pageNumber, PAGE_SIZE));
     }
 
 }
-
-
-

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/usecase/ArticleUseCase.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/article/usecase/ArticleUseCase.java
@@ -1,5 +1,6 @@
 package com.a301.newsseug.domain.article.usecase;
 
+import com.a301.newsseug.domain.article.model.dto.ArticleSummaryDto;
 import com.a301.newsseug.domain.article.model.dto.response.GetArticleSummaryResponseDto;
 import com.a301.newsseug.domain.article.model.dto.response.GetArticleDetailResponseDto;
 import com.a301.newsseug.domain.article.model.entity.Article;
@@ -21,6 +22,10 @@ import com.a301.newsseug.domain.press.service.PressCacheManager;
 import com.a301.newsseug.global.model.dto.SlicedResponse;
 import com.a301.newsseug.global.model.entity.SliceDetails;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -49,7 +54,6 @@ public class ArticleUseCase {
     public GetArticleDetailResponseDto retrieveArticleDetails(
             CustomUserDetails userDetails, Long articleId
     ) {
-
         Article article = articleCacheManager.getCachedArticle(articleId);
 
         Member loginedMember = null;
@@ -88,7 +92,6 @@ public class ArticleUseCase {
                         article.getHateCount() + hateCount
                 )
         );
-
     }
 
     /**
@@ -99,10 +102,13 @@ public class ArticleUseCase {
      * @param pageNumber    페이지 번호
      */
     public SlicedResponse<List<GetArticleSummaryResponseDto>> retrieveArticlesByCategory(String category, int pageNumber) {
-        Slice<GetArticleSummaryResponseDto> articleSummaries = articleRetrieveService.getSlicedArticlesByCategory(CategoryType.from(category), pageNumber);
+        Slice<ArticleSummaryDto> articleSummaries = articleRetrieveService.getSlicedArticlesByCategory(CategoryType.from(category), pageNumber);
+        Map<Long, Press> pressMap = fetchPressMap(articleSummaries);
         return SlicedResponse.of(
                 SliceDetails.of(articleSummaries.getNumber(), articleSummaries.isFirst(), articleSummaries.hasNext()),
-                articleSummaries.getContent()
+                articleSummaries.getContent().stream()
+                        .map(dto -> GetArticleSummaryResponseDto.of(dto, pressMap.get(dto.getPressId())))
+                        .toList()
         );
     }
 
@@ -124,10 +130,19 @@ public class ArticleUseCase {
      * @param pageNumber    페이지 번호
      */
     public SlicedResponse<List<GetArticleSummaryResponseDto>> retrieveTodayArticles(String category, int pageNumber) {
-        Slice<GetArticleSummaryResponseDto> articleSummaries = articleRetrieveService.getSlicedTodayArticlesByCategory(CategoryType.from(category), pageNumber);
+        Slice<ArticleSummaryDto> articleSummaries = articleRetrieveService.getSlicedTodayArticlesByCategory(CategoryType.from(category), pageNumber);
+        Map<Long, Press> pressMap = fetchPressMap(articleSummaries);
+        pressCacheManager.getPressMapFromCache(
+                articleSummaries.getContent().stream()
+                        .map(ArticleSummaryDto::getPressId)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toUnmodifiableSet())
+        );
         return SlicedResponse.of(
                 SliceDetails.of(articleSummaries.getNumber(), articleSummaries.isFirst(), articleSummaries.hasNext()),
-                articleSummaries.getContent()
+                articleSummaries.getContent().stream()
+                        .map(dto -> GetArticleSummaryResponseDto.of(dto, pressMap.get(dto.getPressId())))
+                        .toList()
         );
     }
 
@@ -143,11 +158,12 @@ public class ArticleUseCase {
             Long pressId, String category, int pageNumber
     ) {
         Press press = pressCacheManager.getCachedPress(pressId);
-        Slice<GetArticleSummaryResponseDto> articleSummaries =
-                articleRetrieveService.getSlicedArticlesByPressAndCategory(press, CategoryType.from(category), pageNumber);
+        Slice<ArticleSummaryDto> articleSummaries = articleRetrieveService.getSlicedArticlesByPressAndCategory(press, CategoryType.from(category), pageNumber);
         return SlicedResponse.of(
                 SliceDetails.of(articleSummaries.getNumber(), articleSummaries.isFirst(), articleSummaries.hasNext()),
-                articleSummaries.getContent()
+                articleSummaries.getContent().stream()
+                        .map(dto -> GetArticleSummaryResponseDto.of(dto, press))
+                        .toList()
         );
     }
 
@@ -163,7 +179,11 @@ public class ArticleUseCase {
             CustomUserDetails userDetails, String category, int pageNumber
     ) {
         List<Subscribe> subscribes = subscribeService.getSubscribeByMember(userDetails.getMember());
-        Slice<GetArticleSummaryResponseDto> articleSummaries =
+        Map<Long, Press> pressMap = subscribes.stream()
+                .map(Subscribe::getPress)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(Press::getId, Function.identity(), (a,b) -> a));
+        Slice<ArticleSummaryDto> articleSummaries =
                 articleQueryService.getSlicedArticlesBySubscribedPress(
                         subscribes.stream().map(Subscribe::getPress).toList(),
                         CategoryType.from(category),
@@ -171,7 +191,18 @@ public class ArticleUseCase {
                 );
         return SlicedResponse.of(
                 SliceDetails.of(articleSummaries.getNumber(), articleSummaries.isFirst(), articleSummaries.hasNext()),
-                articleSummaries.getContent()
+                articleSummaries.getContent().stream()
+                        .map(dto -> GetArticleSummaryResponseDto.of(dto, pressMap.get(dto.getPressId())))
+                        .toList()
+        );
+    }
+
+    private Map<Long, Press> fetchPressMap(Slice<ArticleSummaryDto> slice) {
+        return pressCacheManager.getPressMapFromCache(
+                slice.getContent().stream()
+                        .map(ArticleSummaryDto::getPressId)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toUnmodifiableSet())
         );
     }
 

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/auth/model/entity/CustomUserDetails.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/auth/model/entity/CustomUserDetails.java
@@ -25,7 +25,7 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singletonList(
-                (GrantedAuthority) () -> member.getOAuth2Details().getRole().name()
+                (GrantedAuthority) () -> member.getRole().getAuthority()
         );
     }
 

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/usecase/InteractionUseCase.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/interaction/usecase/InteractionUseCase.java
@@ -1,23 +1,25 @@
 package com.a301.newsseug.domain.interaction.usecase;
 
+import com.a301.newsseug.domain.article.model.dto.ArticleSummaryDto;
 import com.a301.newsseug.domain.article.model.dto.response.GetArticleSummaryResponseDto;
 import com.a301.newsseug.domain.article.service.ArticleQueryService;
 import com.a301.newsseug.domain.auth.model.entity.CustomUserDetails;
 import com.a301.newsseug.domain.interaction.model.dto.response.SearchResponse;
 import com.a301.newsseug.domain.member.model.entity.Subscribe;
 import com.a301.newsseug.domain.member.service.SubscribeService;
-import com.a301.newsseug.domain.press.model.dto.PressDetailDto;
 import com.a301.newsseug.domain.press.model.dto.PressSummaryDto;
-import com.a301.newsseug.domain.press.model.dto.response.GetPressDetailResponseDto;
 import com.a301.newsseug.domain.press.model.dto.response.GetPressSummaryResponseDto;
 import com.a301.newsseug.domain.press.model.entity.Press;
+import com.a301.newsseug.domain.press.service.PressCacheManager;
 import com.a301.newsseug.domain.press.service.PressQueryService;
 import com.a301.newsseug.global.model.dto.SlicedResponse;
 import com.a301.newsseug.global.model.entity.SliceDetails;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
@@ -30,15 +32,21 @@ public class InteractionUseCase {
 
     private final ArticleQueryService articleQueryService;
     private final PressQueryService pressQueryService;
+    private final PressCacheManager pressCacheManager;
     private final SubscribeService subscribeService;
 
     public SearchResponse search(CustomUserDetails userDetails, String keyword, int pageNumber) {
 
-        Slice<GetArticleSummaryResponseDto> slicedArticles = articleQueryService.getSlicedArticlesByTitle(keyword, pageNumber);
+        Slice<ArticleSummaryDto> slicedArticles = articleQueryService.getSlicedArticlesByTitle(keyword, pageNumber);
+        Map<Long, Press> pressMap = pressCacheManager.getPressMapFromCache(
+                slicedArticles.getContent().stream()
+                        .map(ArticleSummaryDto::getPressId)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toUnmodifiableSet())
+        );
         List<PressSummaryDto> pressSummaries = pressQueryService.getPressesByName(keyword);
 
         if (userDetails.isEnabled()) {
-
             Set<Press> subscribedPress = new HashSet<>(
                     subscribeService.getSubscribeByMember(userDetails.getMember()).stream()
                             .map(Subscribe::getPress)
@@ -49,17 +57,20 @@ public class InteractionUseCase {
                     GetPressSummaryResponseDto.of(pressSummaries, subscribedPress),
                     SlicedResponse.of(
                             SliceDetails.of(slicedArticles.getNumber(), slicedArticles.isFirst(), slicedArticles.hasNext()),
-                            slicedArticles.getContent()
+                            slicedArticles.getContent().stream()
+                                    .map(dto -> GetArticleSummaryResponseDto.of(dto, pressMap.get(dto.getPressId())))
+                                    .toList()
                     )
             );
-
         }
 
         return SearchResponse.of(
                 GetPressSummaryResponseDto.of(pressSummaries),
                 SlicedResponse.of(
                         SliceDetails.of(slicedArticles.getNumber(), slicedArticles.isFirst(), slicedArticles.hasNext()),
-                        slicedArticles.getContent()
+                        slicedArticles.getContent().stream()
+                                .map(dto -> GetArticleSummaryResponseDto.of(dto, pressMap.get(dto.getPressId())))
+                                .toList()
                 )
         );
 

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/member/model/entity/Subscribe.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/member/model/entity/Subscribe.java
@@ -1,6 +1,5 @@
 package com.a301.newsseug.domain.member.model.entity;
 
-
 import com.a301.newsseug.domain.press.model.entity.Press;
 import com.a301.newsseug.global.model.entity.BaseEntity;
 import jakarta.persistence.Entity;
@@ -10,7 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;

--- a/backend/newsseug/src/main/java/com/a301/newsseug/domain/press/service/PressCacheManager.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/domain/press/service/PressCacheManager.java
@@ -1,11 +1,12 @@
 package com.a301.newsseug.domain.press.service;
 
-import com.a301.newsseug.domain.article.model.entity.Article;
 import com.a301.newsseug.domain.press.model.entity.Press;
 import com.a301.newsseug.domain.press.repository.PressRepository;
 import com.a301.newsseug.external.caffeine.CacheTypes;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
@@ -23,15 +24,19 @@ public class PressCacheManager {
         return pressRepository.findOrThrow(id);
     }
 
+    public Map<Long, Press> getPressMapFromCache(Set<Long> ids) {
+        return ids.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(id -> id, this::getCachedPress));
+    }
+
     public void evict(Long id) {
         Objects.requireNonNull(cacheManager.getCache(CacheTypes.PRESS.getName())).evict(id);
     }
 
-    public void evictBatch(Set<String> ids) {
-        ids.forEach(id ->
-                Objects.requireNonNull(cacheManager.getCache(CacheTypes.PRESS.getName()))
-                        .evict(Long.parseLong(id))
-        );
+    public void evictBatch(Set<Long> ids) {
+        var cache = Objects.requireNonNull(cacheManager.getCache(CacheTypes.PRESS.getName()));
+        ids.forEach(cache::evict);
     }
 
 }

--- a/backend/newsseug/src/main/java/com/a301/newsseug/global/config/SecurityConfig.java
+++ b/backend/newsseug/src/main/java/com/a301/newsseug/global/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.a301.newsseug.global.config;
 import static com.a301.newsseug.domain.member.model.entity.type.RoleType.*;
 
 import com.a301.newsseug.domain.auth.usecase.AuthUseCase;
-import com.a301.newsseug.external.jwt.usecase.JwtUseCase;
 import com.a301.newsseug.external.oauth.service.CustomOAuth2UserService;
 import com.a301.newsseug.external.jwt.filter.JwtAuthenticationFilter;
 import com.a301.newsseug.external.jwt.handler.JwtAccessDeniedHandler;
@@ -38,7 +37,6 @@ public class SecurityConfig {
     };
 
     private final AuthUseCase authUseCase;
-    private final JwtUseCase jwtUseCase;
     private final CustomOAuth2UserService oAuth2UserService;
     private final CorsConfigurationSource corsConfigurationSource;
     private final JwtAccessDeniedHandler accessDeniedHandler;
@@ -85,7 +83,7 @@ public class SecurityConfig {
                                         .successHandler(oAuth2AuthenticationSuccessHandler)
                 )
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(authUseCase, jwtUseCase),
+                        new JwtAuthenticationFilter(authUseCase),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .exceptionHandling(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 없음
* 성능 개선
  * 기사 목록 조회/검색에 캐시 활용을 확대해 응답 속도와 안정성을 향상했습니다.
* 버그 수정
  * 사용자 권한 산출 로직을 정정해 로그인 후 올바른 권한이 부여되도록 했습니다.
* 리팩터링
  * 기사 요약 응답 구조를 경량화하고, 언론사 정보 처리를 일관되게 개선했습니다.
* 기타(Chores)
  * 보안 필터 구성을 단순화하고 불필요한 의존성과 임포트를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->